### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,4 +1,6 @@
 name: gitleaks
+permissions:
+  contents: read
 on: [pull_request, push, workflow_dispatch]
 jobs:
   scan:


### PR DESCRIPTION
Potential fix for [https://github.com/AathilFelix/telegram-weather-bot/security/code-scanning/1](https://github.com/AathilFelix/telegram-weather-bot/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job to explicitly set the minimum required permissions for the GITHUB_TOKEN. In this case, since the workflow is running a scan (gitleaks) and does not appear to require any write access, the minimal permission of `contents: read` is sufficient. The best way to implement this is to add the following block at the top level of the workflow file (after the `name` and before `on`), or at the job level (under `scan:`). Adding it at the workflow level is preferred for clarity and to ensure all jobs inherit the restriction unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
